### PR TITLE
Refactored get_site_url to get_home_url.

### DIFF
--- a/content/template/detailTemplate/template_A.php
+++ b/content/template/detailTemplate/template_A.php
@@ -22,7 +22,7 @@ else
 		set_transient('eduadmin-listCourses', $edo, 6 * HOUR_IN_SECONDS);
 	}
 
-	$surl = get_site_url();
+	$surl = get_home_url();
 	$cat = get_option('eduadmin-rewriteBaseUrl');
 	$baseUrl = $surl . '/' . $cat;
 

--- a/content/template/detailTemplate/template_B.php
+++ b/content/template/detailTemplate/template_B.php
@@ -11,7 +11,7 @@ if(!$apiKey || empty($apiKey))
 }
 else
 {
-	$surl = get_site_url();
+	$surl = get_home_url();
 	$cat = get_option('eduadmin-rewriteBaseUrl');
 	$baseUrl = $surl . '/' . $cat;
 

--- a/content/template/listTemplate/template_A_listCourses.php
+++ b/content/template/listTemplate/template_A_listCourses.php
@@ -1,7 +1,7 @@
 <?php
 ob_start();
 
-$surl = get_site_url();
+$surl = get_home_url();
 $cat = get_option('eduadmin-rewriteBaseUrl');
 $baseUrl = $surl . '/' . $cat;
 

--- a/content/template/listTemplate/template_A_listEvents.php
+++ b/content/template/listTemplate/template_A_listEvents.php
@@ -1,7 +1,7 @@
 <?php
 ob_start();
 
-$surl = get_site_url();
+$surl = get_home_url();
 $cat = get_option('eduadmin-rewriteBaseUrl');
 $baseUrl = $surl . '/' . $cat;
 

--- a/content/template/listTemplate/template_B_listCourses.php
+++ b/content/template/listTemplate/template_B_listCourses.php
@@ -1,7 +1,7 @@
 <?php
 ob_start();
 
-$surl = get_site_url();
+$surl = get_home_url();
 $cat = get_option('eduadmin-rewriteBaseUrl');
 $baseUrl = $surl . '/' . $cat;
 

--- a/content/template/listTemplate/template_B_listEvents.php
+++ b/content/template/listTemplate/template_B_listEvents.php
@@ -1,7 +1,7 @@
 <?php
 ob_start();
 
-$surl = get_site_url();
+$surl = get_home_url();
 $cat = get_option('eduadmin-rewriteBaseUrl');
 $baseUrl = $surl . '/' . $cat;
 

--- a/content/template/myPagesTemplate/login_tab_header.php
+++ b/content/template/myPagesTemplate/login_tab_header.php
@@ -1,5 +1,5 @@
 <?php
-$surl = get_site_url();
+$surl = get_home_url();
 $cat = get_option('eduadmin-rewriteBaseUrl');
 
 $baseUrl = $surl . '/' . $cat;

--- a/eduadmin.php
+++ b/eduadmin.php
@@ -44,7 +44,7 @@ include_once("includes/_shortcodes.php");
 if(file_exists(dirname(__FILE__) . "/.official.plugin.php"))
 {
 	include_once(".official.plugin.php");
-    
+
 }
 
 function edu_load_language()

--- a/includes/_loginFunctions.php
+++ b/includes/_loginFunctions.php
@@ -66,7 +66,7 @@ function sendForgottenPassword($email) {
 
 function logoutUser()
 {
-	$surl = get_site_url();
+	$surl = get_home_url();
 	$cat = get_option('eduadmin-rewriteBaseUrl');
 
 	$baseUrl = $surl . '/' . $cat;
@@ -124,7 +124,7 @@ else
 					$loginContact = loginContactPerson($_POST['eduadminloginEmail'], $_POST['eduadminpassword']);
 					if($loginContact)
 					{
-						$surl = get_site_url();
+						$surl = get_home_url();
 						$cat = get_option('eduadmin-rewriteBaseUrl');
 
 						$baseUrl = $surl . '/' . $cat;

--- a/includes/_options.php
+++ b/includes/_options.php
@@ -91,7 +91,7 @@ function eduadmin_frontend_content()
 	wp_register_script('eduadmin_apiclient_script', plugins_url('content/script/educlient/edu.apiclient.js', dirname(__FILE__)), false, dateVersion($scriptVersion));
 	wp_localize_script('eduadmin_apiclient_script', 'wp_edu',
 	array(
-		'BaseUrl' => get_option('siteurl'),
+		'BaseUrl' => get_option('home'),
 		'CourseFolder' => get_option('eduadmin-rewriteBaseUrl'),
 		'Phrases' => edu_LoadPhrases(),
 		'ApiKey' => get_option('eduadmin-api-key')
@@ -101,7 +101,7 @@ function eduadmin_frontend_content()
 	$scriptVersion = filemtime(dirname(__DIR__) . '/content/script/frontendjs.js');
 	wp_register_script('eduadmin_frontend_script', plugins_url('content/script/frontendjs.js', dirname(__FILE__)), false, dateVersion($scriptVersion));
 	wp_enqueue_script('eduadmin_frontend_script', false, array('jquery'));
-	
+
 }
 
 function eduadmin_backend_content()

--- a/includes/_shortcodes.php
+++ b/includes/_shortcodes.php
@@ -396,7 +396,7 @@ function eduadmin_get_detailinfo($attributes)
 
 			 if(isset($attributes['bookurl']))
 			 {
-			 	$surl = get_site_url();
+			 	$surl = get_home_url();
 				$cat = get_option('eduadmin-rewriteBaseUrl');
 				$baseUrl = $surl . '/' . $cat;
 				$name = (!empty($selectedCourse->PublicName) ? $selectedCourse->PublicName : $selectedCourse->ObjectName);
@@ -405,7 +405,7 @@ function eduadmin_get_detailinfo($attributes)
 
 			 if(isset($attributes['courseinquiryurl']))
 			 {
-			 	$surl = get_site_url();
+			 	$surl = get_home_url();
 				$cat = get_option('eduadmin-rewriteBaseUrl');
 				$baseUrl = $surl . '/' . $cat;
 				$name = (!empty($selectedCourse->PublicName) ? $selectedCourse->PublicName : $selectedCourse->ObjectName);
@@ -509,7 +509,7 @@ function eduadmin_get_detailinfo($attributes)
 					});
 				}
 
-				$surl = get_site_url();
+				$surl = get_home_url();
 				$cat = get_option('eduadmin-rewriteBaseUrl');
 
 				$lastCity = "";
@@ -583,7 +583,7 @@ function eduadmin_get_detailinfo($attributes)
 
 						'<a class="book-link" href="' . $baseUrl . '/' . makeSlugs($name) . '__' . $selectedCourse->ObjectID . '/book/?eid=' . $ev->EventID . edu_getQueryString("&", array('eid')) . '" style="text-align: center;">' . edu__("Book") . '</a>'
 					:
-						($eventInterestPage != false ? '<a class="inquiry-link" href="' . $baseUrl . '/' . makeSlugs($name) . '__' . $selectedCourse->ObjectID . '/book/interest/?eid=' . $ev->EventID . edu_getQueryString("&") . '">' . edu_e("Inquiry") . '</a>' : '') . 
+						($eventInterestPage != false ? '<a class="inquiry-link" href="' . $baseUrl . '/' . makeSlugs($name) . '__' . $selectedCourse->ObjectID . '/book/interest/?eid=' . $ev->EventID . edu_getQueryString("&") . '">' . edu_e("Inquiry") . '</a>' : '') .
 						'<i class="fullBooked">' . edu__("Full") . '</i>'
 					) . '
 					</div>';
@@ -618,7 +618,7 @@ function eduadmin_get_login_widget($attributes)
 		'eduadmin-loginwidget'
 	);
 
-	$surl = get_site_url();
+	$surl = get_home_url();
 	$cat = get_option('eduadmin-rewriteBaseUrl');
 
 	$baseUrl = $surl . '/' . $cat;

--- a/includes/generalSettings.php
+++ b/includes/generalSettings.php
@@ -59,7 +59,7 @@ if(isset($_REQUEST['act']) && $_REQUEST['act'] == "clearTransients")
 			<p>
 				<?php echo __("Enter the URL you want to use with the application (please check that the URL does not exists)", "eduadmin"); ?>
 			</p>
-			<?php echo get_option('siteurl'); ?>/<input style="width: 200px;" type="text" class="form-control folder" name="eduadmin-rewriteBaseUrl" id="eduadmin-rewriteBaseUrl" value="<?php echo esc_attr(get_option('eduadmin-rewriteBaseUrl')); ?>" placeholder="<?php echo __("URL", "eduadmin"); ?>" />/
+			<?php echo get_option('home'); ?>/<input style="width: 200px;" type="text" class="form-control folder" name="eduadmin-rewriteBaseUrl" id="eduadmin-rewriteBaseUrl" value="<?php echo esc_attr(get_option('eduadmin-rewriteBaseUrl')); ?>" placeholder="<?php echo __("URL", "eduadmin"); ?>" />/
 <?php
 	$pages = get_pages();
 	$eduPages = array();


### PR DESCRIPTION
get_site_url causes problems when using different URLs for WordPress home and backend pages.

**Example**
home `www.example.com`
site_url `www.example.com/wp`

short code would create URLs to `www.example.com/wp/kurser` which are 404s.

Suggest using get_home_url instead of get_site_url as basePath.