### PR TITLE
A compatible composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "MultinetInteractive/EduAdmin-WordPress",
+  "name": "multinetinteractive/eduadmin-wordpress",
   "type": "wordpress-plugin",
   "description": "EduAdmin - WordPress-plugin",
   "homepage": "http://www.multinet.se/",


### PR DESCRIPTION
No mixed letters allowed in name for composer. And please register this WordPress-plugin in packagist so we can use it without custom repository registering! Thanks! :-)