### PR TITLE
WordPress notice used instead of plain echo

### DIFF
--- a/content/template/bookingTemplate/loginView.php
+++ b/content/template/bookingTemplate/loginView.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/bookingTemplate/template_A.php
+++ b/content/template/bookingTemplate/template_A.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/detailTemplate/template_A.php
+++ b/content/template/detailTemplate/template_A.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/detailTemplate/template_B.php
+++ b/content/template/detailTemplate/template_B.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/interestRegTemplate/interestRegEvent.php
+++ b/content/template/interestRegTemplate/interestRegEvent.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/interestRegTemplate/interestRegObject.php
+++ b/content/template/interestRegTemplate/interestRegObject.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/listTemplate/template_A.php
+++ b/content/template/listTemplate/template_A.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/listTemplate/template_B.php
+++ b/content/template/listTemplate/template_B.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/content/template/listTemplate/template_GF.php
+++ b/content/template/listTemplate/template_GF.php
@@ -7,7 +7,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/includes/_loginFunctions.php
+++ b/includes/_loginFunctions.php
@@ -90,7 +90,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {
@@ -98,7 +98,7 @@ else
 	$key = DecryptApiKey($apiKey);
 	if(!$key)
 	{
-		echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+        edu_notice_config_incomplete();
 		return;
 	}
 	$edutoken = get_transient('eduadmin-token');

--- a/includes/_notices.php
+++ b/includes/_notices.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Contains admin notices to the user
+ */
+
+/**
+ * Sets an admin notice to announce that config needs to be done.
+ */
+function edu_notice_config_incomplete()
+{
+    add_action('admin_notices', function () {
+        $class = 'notice notice-error';
+        printf('<div class="%1$s"><p>%2$s</p></div>', $class, edu_notice_config_incomplete_message());
+    });
+}
+
+function edu_notice_config_incomplete_message() {
+    return "Please complete the <strong>EduAdmin</strong> configuration: " .
+        "<a href=\"" . admin_url() . "admin.php?page=eduadmin-settings\">Api Authentication</a>";
+}

--- a/includes/_shortcodes.php
+++ b/includes/_shortcodes.php
@@ -181,7 +181,7 @@ function eduadmin_get_detailinfo($attributes)
 
 	if(!$apiKey || empty($apiKey))
 	{
-		return 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+		return edu_notice_config_incomplete_message();
 	}
 	else
 	{

--- a/includes/bookingSettings.php
+++ b/includes/bookingSettings.php
@@ -11,7 +11,7 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
+    edu_notice_config_incomplete();
 }
 else
 {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,6 +1,7 @@
 <?php
 defined( 'ABSPATH' ) or die( 'This plugin must be run within the scope of WordPress.' );
 
+include_once("_notices.php");
 include_once("_apiFunctions.php");
 include_once("_translationFunctions.php");
 include_once("_questionFunctions.php");

--- a/includes/listSettings.php
+++ b/includes/listSettings.php
@@ -5,8 +5,8 @@ $apiKey = get_option('eduadmin-api-key');
 
 if(!$apiKey || empty($apiKey))
 {
-	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
-	return;
+    edu_notice_config_incomplete();
+    return;
 }
 else
 {


### PR DESCRIPTION
Using WordPress notice functions to alert the administrator that settings (api config) not is set. Also it is gathered in one function instead of duplicating the code all over several places.
Benefits:

- Less complicated code and reused
- Allowed output making the plugin activation good to go instead of activation errors due to non config settings.
- Readable error message in wp-admin for the administrator at every page. Not hidden behind menues :-)
-  