### PR TITLE
Release 2.0.2

### DIFF
--- a/class/class-eduadmin-bookinghandler.php
+++ b/class/class-eduadmin-bookinghandler.php
@@ -118,6 +118,10 @@ class EduAdmin_BookingHandler {
 			$customer->CustomerId = $user->Customer->CustomerId;
 		}
 
+		if ( ! empty( $_POST['edu-customerId'] ) ) {
+			$customer->CustomerId = intval( $_POST['edu-customerId'] );
+		}
+
 		$first = '';
 		$last  = '';
 
@@ -219,6 +223,10 @@ class EduAdmin_BookingHandler {
 			return null;
 		}
 
+		if ( ! empty( $_POST['edu-contactId'] ) ) {
+			$contact->PersonId = intval( $_POST['edu-contactId'] );
+		}
+
 		if ( ! empty( $_POST['contactFirstName'] ) ) {
 			$contact->FirstName = sanitize_text_field( $_POST['contactFirstName'] );
 		}
@@ -250,7 +258,7 @@ class EduAdmin_BookingHandler {
 			$contact->PriceNameId = intval( $_POST['contactPriceName'] );
 		}
 
-		$contact->CanLogin     = true;
+		$contact->CanLogin     = get_option( 'eduadmin-useLogin', false );
 		$contact->Answers      = $this->get_contact_questions();
 		$contact->CustomFields = $this->get_contact_custom_fields();
 		$contact->Sessions     = $this->get_contact_sessions();
@@ -321,6 +329,10 @@ class EduAdmin_BookingHandler {
 			$user                 = EDU()->session['eduadmin-loginUser'];
 			$contact->PersonId    = $user->Contact->PersonId;
 			$customer->CustomerId = $user->Customer->CustomerId;
+		}
+
+		if ( ! empty( $_POST['edu-customerId'] ) ) {
+			$customer->CustomerId = intval( $_POST['edu-customerId'] );
 		}
 
 		if ( ! empty( $_POST['customerName'] ) ) {

--- a/content/template/bookingTemplate/contact-view.php
+++ b/content/template/bookingTemplate/contact-view.php
@@ -1,6 +1,9 @@
 <?php
 $block_edit_if_logged_in = get_option( 'eduadmin-blockEditIfLoggedIn', true );
 $__block                 = ( $block_edit_if_logged_in && isset( $contact->PersonId ) && 0 !== $contact->PersonId );
+if ( isset( $contact->PersonId ) && 0 !== $contact->PersonId ) {
+	echo '<input type="hidden" name="edu-contactId" value="' . esc_attr( $contact->PersonId ) . '" />';
+}
 ?>
 <div class="contactView">
 	<h2><?php esc_html_e( 'Contact information', 'eduadmin-booking' ); ?></h2>

--- a/content/template/bookingTemplate/customer-view.php
+++ b/content/template/bookingTemplate/customer-view.php
@@ -5,6 +5,10 @@ if ( ! empty( $customer->BillingInfo ) ) {
 } else {
 	$billing_customer = new EduAdmin_Data_BillingInfo();
 }
+
+if ( isset( $customer->CustomerId ) && 0 !== $customer->CustomerId ) {
+	echo '<input type="hidden" name="edu-customerId" value="' . esc_attr( $customer->CustomerId ) . '" />';
+}
 ?>
 <div class="customerView">
 	<h2><?php esc_html_e( 'Customer information', 'eduadmin-booking' ); ?></h2>

--- a/content/template/bookingTemplate/single-person-booking.php
+++ b/content/template/bookingTemplate/single-person-booking.php
@@ -8,6 +8,12 @@ if ( ! empty( $customer->BillingInfo ) ) {
 } else {
 	$billing_customer = new EduAdmin_Data_BillingInfo();
 }
+if ( isset( $contact->PersonId ) && 0 !== $contact->PersonId ) {
+	echo '<input type="hidden" name="edu-contactId" value="' . esc_attr( $contact->PersonId ) . '" />';
+}
+if ( isset( $customer->CustomerId ) && 0 !== $customer->CustomerId ) {
+	echo '<input type="hidden" name="edu-customerId" value="' . esc_attr( $customer->CustomerId ) . '" />';
+}
 ?>
 <div class="contactView">
 	<h2><?php esc_html_e( 'Contact information', 'eduadmin-booking' ); ?></h2>

--- a/content/template/interestRegTemplate/interest-reg-event.php
+++ b/content/template/interestRegTemplate/interest-reg-event.php
@@ -6,7 +6,7 @@ $api_key = get_option( 'eduadmin-api-key' );
 if ( ! $api_key || empty( $api_key ) ) {
 	echo 'Please complete the configuration: <a href="' . admin_url() . 'admin.php?page=eduadmin-settings">EduAdmin - Api Authentication</a>';
 } else {
-	if ( wp_verify_nonce( $_POST['edu-interest-nonce'], 'edu-event-interest' ) && isset( $_POST['act'] ) && 'eventInquiry' === sanitize_text_field( $_POST['act'] ) ) {
+	if ( ! empty( $_POST['edu-interest-nonce'] ) && wp_verify_nonce( $_POST['edu-interest-nonce'], 'edu-event-interest' ) && isset( $_POST['act'] ) && 'eventInquiry' === sanitize_text_field( $_POST['act'] ) ) {
 		include_once 'send-event-inquiry.php';
 	}
 

--- a/content/template/interestRegTemplate/interest-reg-object.php
+++ b/content/template/interestRegTemplate/interest-reg-object.php
@@ -6,7 +6,7 @@ $api_key = get_option( 'eduadmin-api-key' );
 if ( ! $api_key || empty( $api_key ) ) {
 	echo 'Please complete the configuration: <a href="' . esc_url( admin_url() . 'admin.php?page=eduadmin-settings' ) . '">EduAdmin - Api Authentication</a>';
 } else {
-	if ( wp_verify_nonce( $_POST['edu-interest-nonce'], 'edu-object-interest' ) && isset( $_POST['act'] ) && 'objectInquiry' === sanitize_text_field( $_POST['act'] ) ) {
+	if ( ! empty( $_POST['edu-interest-nonce'] ) && wp_verify_nonce( $_POST['edu-interest-nonce'], 'edu-object-interest' ) && isset( $_POST['act'] ) && 'objectInquiry' === sanitize_text_field( $_POST['act'] ) ) {
 		include_once 'send-object-inquiry.php';
 	}
 

--- a/content/template/programme/template/detail-list.php
+++ b/content/template/programme/template/detail-list.php
@@ -1,5 +1,4 @@
 <?php
-
 $grouped_programmes = array();
 
 foreach ( $programme['ProgrammeStarts'] as $programme_start ) {
@@ -23,7 +22,7 @@ foreach ( $grouped_programmes as $group => $grouped_programme ) {
 		echo '<td>' . wp_kses_post( get_display_date( $programme_start['StartDate'] ) ) . '</td>';
 		echo '<td><i>Left intentionally empty</i></td>';
 		echo '<td>' . esc_html( $programme_start['ParticipantNumberLeft'] > 0 ? __( 'Yes', 'eduadmin-booking' ) : __( 'No', 'eduadmin-booking' ) ) . '</td>';
-		echo '<td><a href="#" class="submit-programme">' . esc_html__( 'Book', 'eduadmin-booking' ) . '</a></td>';
+		echo '<td><a href="' . esc_url( get_home_url() . '/programmes/' . make_slugs( $programme['ProgrammeName'] ) . '_' . $programme['ProgrammeId'] . '/book/?id=' . $programme_start['ProgrammeStartId'] ) . '" class="submit-programme">' . esc_html__( 'Book', 'eduadmin-booking' ) . '</a></td>';
 		echo '</tr>';
 	}
 	echo '</table>';

--- a/content/template/programme/template/detail-list.php
+++ b/content/template/programme/template/detail-list.php
@@ -1,1 +1,32 @@
 <?php
+
+$grouped_programmes = array();
+
+foreach ( $programme['ProgrammeStarts'] as $programme_start ) {
+	$key = date( 'Y-m', strtotime( $programme_start['StartDate'] ) );
+
+	$grouped_programmes[ $key ][] = $programme_start;
+}
+
+foreach ( $grouped_programmes as $group => $grouped_programme ) {
+	echo '<h2>' . esc_html( $group ) . '</h2>';
+	echo '<div class="scrollable">';
+	echo '<table class="programme-list">';
+	echo '<tr>';
+	echo '<th>' . esc_html__( 'Start', 'eduadmin-booking' ) . '</th>';
+	echo '<th>' . esc_html__( 'Schedule', 'eduadmin-booking' ) . '</th>';
+	echo '<th>' . esc_html__( 'Spots left', 'eduadmin-booking' ) . '</th>';
+	echo '<th></th>';
+	echo '</tr>';
+	foreach ( $grouped_programme as $programme_start ) {
+		echo '<tr>';
+		echo '<td>' . wp_kses_post( get_display_date( $programme_start['StartDate'] ) ) . '</td>';
+		echo '<td><i>Left intentionally empty</i></td>';
+		echo '<td>' . esc_html( $programme_start['ParticipantNumberLeft'] > 0 ? __( 'Yes', 'eduadmin-booking' ) : __( 'No', 'eduadmin-booking' ) ) . '</td>';
+		echo '<td><a href="#" class="submit-programme">' . esc_html__( 'Book', 'eduadmin-booking' ) . '</a></td>';
+		echo '</tr>';
+	}
+	echo '</table>';
+	echo '</div>';
+	EDU()->write_debug( $grouped_programme );
+}

--- a/includes/edu-login-functions.php
+++ b/includes/edu-login-functions.php
@@ -15,7 +15,7 @@ function edu_send_forgotten_password( $login_value ) {
 		true
 	);
 
-	if ( 1 === $cc['@odata.count'] ) {
+	if ( 1 === count( $cc['value'] ) ) {
 		$cc_id = current( $cc['value'] )['PersonId'];
 	}
 
@@ -84,4 +84,5 @@ add_action(
 				}
 			}
 		}
-	} );
+	}
+);

--- a/includes/edu-shortcodes.php
+++ b/includes/edu-shortcodes.php
@@ -634,10 +634,12 @@ function eduadmin_get_programme_list( $attributes ) {
 		'HasPublicPriceName' .
 		' and (ApplicationOpenDate le ' . date( 'c' ) . ' or ApplicationOpenDate eq null)' .
 		' and StartDate ge ' . date( 'c' ) .
+		//' and Courses/any()' .
 		';' .
 		'$orderby=' .
 		'StartDate),Courses'
 	);
+
 	include_once EDUADMIN_PLUGIN_PATH . '/content/template/programme/list.php';
 }
 
@@ -670,9 +672,14 @@ function eduadmin_get_programme_details( $attributes ) {
 			'HasPublicPriceName' .
 			' and (ApplicationOpenDate le ' . date( 'c' ) . ' or ApplicationOpenDate eq null)' .
 			' and StartDate ge ' . date( 'c' ) .
+			//' and Courses/any()' .
 			';' .
 			'$orderby=' .
-			'StartDate),Courses,PriceNames'
+			'StartDate' .
+			';' .
+			'$expand=' .
+			'Courses,Events' .
+			'),Courses,PriceNames'
 		);
 
 		include_once EDUADMIN_PLUGIN_PATH . '/content/template/programme/detail.php';

--- a/includes/edu-shortcodes.php
+++ b/includes/edu-shortcodes.php
@@ -634,7 +634,6 @@ function eduadmin_get_programme_list( $attributes ) {
 		'HasPublicPriceName' .
 		' and (ApplicationOpenDate le ' . date( 'c' ) . ' or ApplicationOpenDate eq null)' .
 		' and StartDate ge ' . date( 'c' ) .
-		//' and Courses/any()' .
 		';' .
 		'$orderby=' .
 		'StartDate),Courses'
@@ -672,7 +671,6 @@ function eduadmin_get_programme_details( $attributes ) {
 			'HasPublicPriceName' .
 			' and (ApplicationOpenDate le ' . date( 'c' ) . ' or ApplicationOpenDate eq null)' .
 			' and StartDate ge ' . date( 'c' ) .
-			//' and Courses/any()' .
 			';' .
 			'$orderby=' .
 			'StartDate' .

--- a/includes/general-settings.php
+++ b/includes/general-settings.php
@@ -78,6 +78,10 @@ function edu_render_general_settings() {
 						$eduPages[] = $p;
 					}
 				}
+
+				if ( 0 === count( $eduPages ) ) {
+					$eduPages = $pages;
+				}
 				?>
 				<h3><?php esc_html_e( 'Course templates', 'eduadmin-booking' ); ?></h3>
 				<table>
@@ -257,6 +261,10 @@ function edu_render_general_settings() {
 					if ( strstr( $p->post_content, '[eduadmin' ) ) {
 						$programme_pages[] = $p;
 					}
+				}
+
+				if ( 0 === count( $programme_pages ) ) {
+					$programme_pages = $pages;
 				}
 				?>
 				<h3><?php _e( 'Programmes', 'eduadmin-booking' ); ?></h3>

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ and redo your own customization.
 - fix: Adding check for nonces in interest-registration pages
 - fix: Checking count in password reset in a different way
 - add: When you activate/deactivate the plugin, all transients are now cleaned
+- add: Programme start list in detail view
+- add: Save `customerId` and `personId` in hidden variables on booking page, so we won't lose logged in users if the session times out.
 
 ### 2.0.1 ###
 - chg: Better check against `customtemplate`

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ and redo your own customization.
 - add: When you activate/deactivate the plugin, all transients are now cleaned
 - add: Programme start list in detail view
 - add: Save `customerId` and `personId` in hidden variables on booking page, so we won't lose logged in users if the session times out.
+- add: If we cannot find anything related to `[eduadmin` in the pages, show all pages.
 
 ### 2.0.1 ###
 - chg: Better check against `customtemplate`

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,11 @@ and redo your own customization.
 
 == Changelog ==
 
+### 2.0.2 ###
+- fix: Adding check for nonces in interest-registration pages
+- fix: Checking count in password reset in a different way
+- add: When you activate/deactivate the plugin, all transients are now cleaned
+
 ### 2.0.1 ###
 - chg: Better check against `customtemplate`
 - add: Backend-function to fix old search/sort/display values to the new ones

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Contributors: mnchga
 Tags: booking, participants, courses, events, eduadmin, lega online
 Requires at least: 4.7
 Tested up to: 4.9
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 Requires PHP: 5.2
 License: GPL3
 License-URI: https://www.gnu.org/licenses/gpl-3.0.en.html


### PR DESCRIPTION
- fix: Adding check for nonces in interest-registration pages
- fix: Checking count in password reset in a different way
- add: When you activate/deactivate the plugin, all transients are now cleaned
- add: Programme start list in detail view
- add: Save `customerId` and `personId` in hidden variables on booking page, so we won't lose logged in users if the session times out.