### PR TITLE
fix, run flush_rewrite_rules() when saving options

### DIFF
--- a/eduadmin.php
+++ b/eduadmin.php
@@ -353,7 +353,7 @@ if ( ! class_exists( 'EduAdmin' ) ) :
 		}
 
 		public function new_theme() {
-			update_option( 'eduadmin-options_have_changed', true );
+			update_option( 'eduadmin-options_have_changed', 1 );
 		}
 
 		public function activate() {

--- a/includes/edu-rewrites.php
+++ b/includes/edu-rewrites.php
@@ -67,9 +67,9 @@ function eduadmin_rewrite_init() {
 		}
 	}
 
-	if ( true === get_option( 'eduadmin-options_have_changed', 'false' ) ) {
+	if ( true == get_option( 'eduadmin-options_have_changed', 0 ) ) {
 		flush_rewrite_rules();
-		update_option( 'eduadmin-options_have_changed', false );
+		update_option( 'eduadmin-options_have_changed', 0 );
 	}
 	EDU()->stop_timer( $t );
 }


### PR DESCRIPTION
update_option does not store boolean true or false.
bool true is stored as int 1 and bool false is stored as empty string.

so, true === get_option() will never happen.

(fyi, a small inconsistency, in general-settings.php the setting is set to string true.  since true == "true" that still works)




