### PR TITLE
Prep 2.0.18

### DIFF
--- a/eduadmin.php
+++ b/eduadmin.php
@@ -9,7 +9,7 @@ defined( 'WP_SESSION_COOKIE' ) || define( 'WP_SESSION_COOKIE', 'eduadmin-cookie'
  * Plugin URI:	https://www.eduadmin.se
  * Description:	EduAdmin plugin to allow visitors to book courses at your website
  * Tags:	booking, participants, courses, events, eduadmin, lega online
- * Version:	2.0.17
+ * Version:	2.0.18
  * GitHub Plugin URI: multinetinteractive/eduadmin-wordpress
  * GitHub Plugin URI: https://github.com/multinetinteractive/eduadmin-wordpress
  * Requires at least: 4.7

--- a/includes/edu-text-functions.php
+++ b/includes/edu-text-functions.php
@@ -238,7 +238,7 @@ function get_logical_date_groups( $dates, $short = false, $event = null, $show_d
 
 // Copied from http://codereview.stackexchange.com/a/83095/27610
 function get_range_from_days( $days, $short, $event, $show_days ) {
-	sort( $days );
+	usort( $days, "DateComparer" );
 	$start_date  = $days[0];
 	$finish_date = $days[ count( $days ) - 1 ];
 	$result      = array();

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Contributors: mnchga
 Tags: booking, participants, courses, events, eduadmin, lega online
 Requires at least: 4.7
 Tested up to: 4.9
-Stable tag: 2.0.17
+Stable tag: 2.0.18
 Requires PHP: 5.2
 License: GPL3
 License-URI: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -36,6 +36,9 @@ We have replaced everything with a new API-client, so some things may be broken.
 If you notice that your API key doesn't work any more, you have to contact us.
 
 == Changelog ==
+
+### 2.0.18
+-   fix: Proper sorting on event dates. (Using `sort` on an `array` was stupid)..
 
 ### 2.0.17
 -   fix: Code styling and small fixes


### PR DESCRIPTION
-   fix: Proper sorting on event dates. (Using `sort` on an `array` was stupid)..